### PR TITLE
Add Puppet 5 to matrix for travis and appveyor

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -6,6 +6,7 @@
     '*.pp': 'eol=lf'
     '*.sh': 'eol=lf'
 .travis.yml:
+  script: "\"bundle exec rake release_checks\""
   ruby_versions:
     - 2.4.1
     - 2.1.9
@@ -25,6 +26,9 @@
     - env: CHECK=rubocop
     - env: CHECK="syntax lint"
     - env: CHECK=metadata_lint
+    - rvm: 2.4.1
+      env: PUPPET_GEM_VERSION="~> 5.0"
+      bundler_args: --without system_tests
 appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
   environment:
@@ -40,6 +44,10 @@ appveyor.yml:
       CHECK: spec
     - RUBY_VERSION: 21-x64
       CHECK: spec
+    - PUPPET_GEM_VERSION: '~> 5.0'
+      RUBY_VER: 24
+    - PUPPET_GEM_VERSION: '~> 5.0'
+      RUBY_VER: 24-x64
   test_script:
     - bundle exec rake %CHECK%
 Rakefile:


### PR DESCRIPTION
Also has the addition of 'release_checks' in .travis to run the release
checks rake task.

This PR is an attempt to bring the default configuration closer
to that of config_defaults in modulesync_configs.